### PR TITLE
Fix: When searching through chats, every new symbol forces the search…

### DIFF
--- a/src/Components/ColumnLeft/Search/Search.js
+++ b/src/Components/ColumnLeft/Search/Search.js
@@ -22,7 +22,7 @@ import SearchCaption from './SearchCaption';
 import { loadChatsContent, loadUsersContent } from '../../../Utils/File';
 import { filterMessages } from '../../../Utils/Message';
 import { getCyrillicInput, getLatinInput } from '../../../Utils/Language';
-import { orderCompare } from '../../../Utils/Common';
+import { orderCompare, equal } from '../../../Utils/Common';
 import { USERNAME_LENGTH_MIN } from '../../../Constants';
 import MessageStore from '../../../Stores/MessageStore';
 import FileStore from '../../../Stores/FileStore';
@@ -184,14 +184,6 @@ class Search extends React.Component {
                     local.splice(0, 0, savedMessages.id);
                 }
             }
-
-            this.setState({
-                top: null,
-                recentlyFound: null,
-                local: local,
-                global: null,
-                messages: null
-            });
 
             store = FileStore.getStore();
             loadChatsContent(store, local);
@@ -474,6 +466,32 @@ class Search extends React.Component {
 
         onClose();
     };
+
+    isTheSame = (nextState, field, compareField) => {
+        const a1 = this.state[field],
+            a2 = nextState[field],
+            l1 = a1 && a1.length,
+            l2 = a2 && a2.length;
+
+        if (!a1 && !a2) return true;
+
+        if (l1 !== l2) return false;
+
+        return equal(a1[compareField], a2[compareField]);
+    };
+
+    shouldComponentUpdate(nextProps, nextState) {
+        if (!equal(this.state.local, nextState.local) || !equal(this.state.global, nextState.global)) return true;
+
+        if (
+            !this.isTheSame(nextState, 'recentlyFound', 'chat_ids') ||
+            !this.isTheSame(nextState, 'top', 'chat_ids') ||
+            !this.isTheSame(nextState, 'messages', 'messages')
+        )
+            return true;
+
+        return false;
+    }
 
     render() {
         const { classes, chatId } = this.props;

--- a/src/Utils/Common.js
+++ b/src/Utils/Common.js
@@ -83,6 +83,23 @@ function orderCompare(order1, order2) {
     return order1 > order2 ? 1 : -1;
 }
 
+function equal(a1, a2) {
+    if (!(a1 instanceof Array && a2 instanceof Array)) return a1 === a2;
+
+    const l1 = a1.length,
+        l2 = a2.length;
+
+    if (l1 !== l2) return false;
+
+    for (var i = 0; i < l1; i++) {
+        if (typeof a1[i] === 'object' && typeof a2[i] === 'object') {
+            if (a1[i].id !== a2[i].id) return false;
+        } else if (a1[i] !== a2[i]) return false;
+    }
+
+    return true;
+}
+
 function getPhotoThumbnailSize(sizes) {
     return getSize(sizes, PHOTO_THUMBNAIL_SIZE);
 }
@@ -385,5 +402,6 @@ export {
     isAuthorizationReady,
     between,
     getDurationString,
-    getRandomInt
+    getRandomInt,
+    equal
 };


### PR DESCRIPTION
… to hide the current query which may cause blinking if a new query matches the old one.