### PR TITLE
Add support for strike-through + underline text format

### DIFF
--- a/src/Components/ColumnLeft/Settings/EditProfile.js
+++ b/src/Components/ColumnLeft/Settings/EditProfile.js
@@ -19,7 +19,7 @@ import FileStore from '../../../Stores/FileStore';
 import UserStore from '../../../Stores/UserStore';
 import TdLibController from '../../../Controllers/TdLibController';
 import './EditProfile.css';
-import { getBoldItalicEntities, getFormattedText } from '../../../Utils/Message';
+import { getSimpleMarkupEntities, getFormattedText } from '../../../Utils/Message';
 
 class EditProfile extends React.Component {
     constructor(props) {
@@ -176,7 +176,7 @@ class EditProfile extends React.Component {
 
         const src = getSrc(photo ? photo.small : null);
         const entities = [];
-        const text = getBoldItalicEntities(t('UsernameHelp'), entities);
+        const text = getSimpleMarkupEntities(t('UsernameHelp'), entities);
         const formattedText = getFormattedText({ '@type': 'formattedText', text, entities });
 
         return (


### PR DESCRIPTION
- Rename and generalize `getSimpleMarkupEntities` (formerly `getBoldItalicEntities`)
- Add switch cases for both directions of conversion of the new formatting entity types
- Add markup syntax for strikethrough by enclosing a word into tildes (`~`)

This is my first PR to this repo, so please review carefully before merging. 😉 I did not run any tests manually, but I ran the webserver locally and successfully sent a message with the new formatting to myself and nothing crashed!

![image](https://user-images.githubusercontent.com/38782922/91670400-6045fd80-eb1d-11ea-93b2-ddf96e4da9e0.png)
