### PR TITLE
Fix Instant View text cropping issue

### DIFF
--- a/src/Components/InstantView/Article.css
+++ b/src/Components/InstantView/Article.css
@@ -10,7 +10,7 @@ article {
     font-family: 'Helvetica Neue';
     font-size: 17px;
     line-height: 25px;
-    padding: 0;
+    padding-bottom: 1em;
     margin: 0 auto;
     height: 100%;
     max-width: 800px;


### PR DESCRIPTION
Explained in #279 
Since top, left, and right paddings are 0, rename the property according to our needs and avoiding clutter.

![image](https://user-images.githubusercontent.com/34194191/100316835-f7f3a480-2fc3-11eb-8070-498b8eca055a.png)
1em should do.