### PR TITLE
Match sidebar link font size with the link preview from the messages section

### DIFF
--- a/src/Components/Tile/SharedMedia/SharedLink.css
+++ b/src/Components/Tile/SharedMedia/SharedLink.css
@@ -30,6 +30,7 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
+    font-size: 14px;
 }
 
 .shared-link-content .web-page-title {


### PR DESCRIPTION
With the current implementation, the font size of link titles and preview text is far too big, so make it match the one in the chats section.
![image](https://user-images.githubusercontent.com/34194191/102931862-dd6bf880-44a7-11eb-9952-8357f1885797.png)

----

![image](https://user-images.githubusercontent.com/34194191/102931989-23c15780-44a8-11eb-9075-ef70cacf34ae.png)

----

![image](https://user-images.githubusercontent.com/34194191/102931836-ccbb8280-44a7-11eb-9363-a831c77fad77.png)
