### PR TITLE
Add the actual resolution of the icon.svg file

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -52,7 +52,7 @@
     {
       "src": "img/icons/icon.svg",
       "type": "image/svg+xml",
-      "sizes": "513x513"
+      "sizes": "620x620"
     }
   ],
   "permissions": [


### PR DESCRIPTION
This pull fixes an error in Chrome and other Chromium-based web browsers.

![image](https://user-images.githubusercontent.com/34194191/105695420-bff8d700-5f0a-11eb-8384-02051c79d998.png)
Google Chrome
----
![image](https://user-images.githubusercontent.com/34194191/105695644-00f0eb80-5f0b-11eb-9016-0ed8d6a8d639.png)
Microsoft Edge
----

The actual resolution of the file was confirmed in Squoosh.
![image](https://user-images.githubusercontent.com/34194191/105695440-c4bd8b00-5f0a-11eb-9278-64a9815638ec.png)
