### PR TITLE
FIx: Firefox thin scrollbar support (css only)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine AS build
+FROM node:14 AS build
 
 WORKDIR /app/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14 AS build
+FROM node:14-alpine AS build
 
 WORKDIR /app/
 
@@ -17,7 +17,7 @@ ENV REACT_APP_TELEGRAM_API_HASH=${TELEGRAM_API_HASH}
 
 RUN npm run build
 
-FROM nginx:stable
+FROM nginx:stable-alpine
 
 WORKDIR /usr/share/nginx/html/
 COPY --from=build /app/build/ .

--- a/public/emoji-mart.dark.css
+++ b/public/emoji-mart.dark.css
@@ -95,6 +95,7 @@
     height: 270px;
     margin-right: -15px;
     padding: 0 6px 6px 6px;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     will-change: transform; /* avoids "repaints on scroll" in mobile Chrome */
 }
 

--- a/public/emoji-mart.light.css
+++ b/public/emoji-mart.light.css
@@ -95,6 +95,7 @@
     height: 270px;
     margin-right: -15px;
     padding: 0 6px 6px 6px;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     will-change: transform; /* avoids "repaints on scroll" in mobile Chrome */
 }
 

--- a/src/Components/Additional/AppInactive.css
+++ b/src/Components/Additional/AppInactive.css
@@ -10,6 +10,7 @@
     height: 100%;
     width: 100%;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
 }
 

--- a/src/Components/Auth/AuthForm.css
+++ b/src/Components/Auth/AuthForm.css
@@ -7,6 +7,7 @@
 
 .authorization-form {
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     overflow-x: hidden;
     height: 100%;

--- a/src/Components/Calls/GroupCallPanel.css
+++ b/src/Components/Calls/GroupCallPanel.css
@@ -92,6 +92,7 @@
 .group-call-panel-participants {
     flex: 1 1 auto;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     margin: 0 16px;
     border-radius: 5px;
     z-index: 1;

--- a/src/Components/Calls/GroupCallSettings.css
+++ b/src/Components/Calls/GroupCallSettings.css
@@ -100,6 +100,7 @@
     flex-direction: column;
     flex: 1 1 auto;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
 }
 

--- a/src/Components/ColumnLeft/Contacts.css
+++ b/src/Components/ColumnLeft/Contacts.css
@@ -40,6 +40,7 @@
     bottom: 0;
     left: 0;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     transform: translateZ(0);
     padding: 8px 8px 8px;
@@ -53,6 +54,7 @@
     transition: max-height 0.25s ease, min-height 0.25s ease;
     overflow-x: hidden;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     flex-grow: 0;
     flex-shrink: 0;

--- a/src/Components/ColumnLeft/DialogsList.css
+++ b/src/Components/ColumnLeft/DialogsList.css
@@ -10,6 +10,7 @@
     background: var(--panel-background);
     overflow-y: scroll;
     -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     overflow-x: hidden;
     height: 100%;
     transform: translateZ(0);

--- a/src/Components/ColumnLeft/Search/Search.css
+++ b/src/Components/ColumnLeft/Search/Search.css
@@ -14,6 +14,7 @@
     left: 0;
     overflow-y: scroll;
     -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     transform: translateZ(0);
     background: var(--panel-background);
     padding: 0 8px;

--- a/src/Components/ColumnLeft/Settings/EditFilterChats.css
+++ b/src/Components/ColumnLeft/Settings/EditFilterChats.css
@@ -12,6 +12,7 @@
     bottom: 0;
     left: 0;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     background: var(--background);
     z-index: 1;

--- a/src/Components/ColumnLeft/SidebarPage.css
+++ b/src/Components/ColumnLeft/SidebarPage.css
@@ -27,6 +27,7 @@
 .sidebar-page-content {
     padding: 0 8px 8px;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     transform: translateZ(0);
 }

--- a/src/Components/ColumnMiddle/GifsPicker.css
+++ b/src/Components/ColumnMiddle/GifsPicker.css
@@ -18,6 +18,7 @@
     padding: 6px;
     height: 356px;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     transform: translateZ(0);
 

--- a/src/Components/ColumnMiddle/InputBox.css
+++ b/src/Components/ColumnMiddle/InputBox.css
@@ -121,6 +121,7 @@
     max-height: 150px;
     overflow-x: hidden;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     padding: 16px 0 16px 0;
     white-space: pre-wrap;

--- a/src/Components/ColumnMiddle/MessagesList.css
+++ b/src/Components/ColumnMiddle/MessagesList.css
@@ -23,6 +23,7 @@
     overflow-x: hidden;
     overflow-y: scroll;
     -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     transform: translateZ(0);
     will-change: transform;
     /*mask-image: linear-gradient(to top, rgba(0, 0, 0, 0) 0px, rgba(0, 0, 0, 1) 15px);*/

--- a/src/Components/ColumnMiddle/StickersHint.css
+++ b/src/Components/ColumnMiddle/StickersHint.css
@@ -19,6 +19,7 @@
     bottom: 4px;
     max-height: 190px;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     display: flex;
     flex-wrap: wrap;

--- a/src/Components/ColumnMiddle/StickersPicker.css
+++ b/src/Components/ColumnMiddle/StickersPicker.css
@@ -19,6 +19,7 @@
     padding: 0 6px 6px;
     height: 356px;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     transform: translateZ(0);
 }

--- a/src/Components/ColumnRight/ChatDetails.css
+++ b/src/Components/ColumnRight/ChatDetails.css
@@ -22,6 +22,7 @@
 .chat-details-list {
     overflow-x: hidden;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     flex-grow: 1;
     flex-shrink: 1;

--- a/src/Components/ColumnRight/GroupsInCommon.css
+++ b/src/Components/ColumnRight/GroupsInCommon.css
@@ -16,6 +16,7 @@
 
 .groups-in-common-list {
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     flex-grow: 1;
     flex-shrink: 1;

--- a/src/Components/ColumnRight/SharedMedia/SharedMediaBase.css
+++ b/src/Components/ColumnRight/SharedMedia/SharedMediaBase.css
@@ -8,6 +8,7 @@
 .shared-media-list {
     height: 100%;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     overflow-x: hidden;
     transform: translateZ(0);
@@ -33,6 +34,7 @@
     bottom: 0;
     left: 0;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     overflow-x: hidden;
     transform: translateZ(0);

--- a/src/Components/InstantView/Blocks/ErrorHandler.css
+++ b/src/Components/InstantView/Blocks/ErrorHandler.css
@@ -18,5 +18,6 @@
     max-height: 150px;
     width: 100%;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     overflow-x: hidden;
 }

--- a/src/Components/InstantView/InstantViewer.css
+++ b/src/Components/InstantView/InstantViewer.css
@@ -13,6 +13,7 @@
     bottom: 0;
     left: 0;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     display: flex;
     background: var(--panel-background);

--- a/src/Components/Player/Playlist.css
+++ b/src/Components/Player/Playlist.css
@@ -24,6 +24,7 @@
     padding: 0 12px;
     overflow-x: hidden;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     box-sizing: border-box;
 }

--- a/src/Components/Popup/CreatePollDialog.css
+++ b/src/Components/Popup/CreatePollDialog.css
@@ -47,6 +47,7 @@
     min-height: 24px;
     overflow-x: hidden;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     padding: 12px 24px 12px 24px;
     white-space: pre-wrap;

--- a/src/Components/Popup/CreatePollOption.css
+++ b/src/Components/Popup/CreatePollOption.css
@@ -75,6 +75,7 @@
     min-height: 24px;
     overflow-x: hidden;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     padding: 12px 64px 12px 24px;
     white-space: pre-wrap;

--- a/src/Components/Popup/EditMediaDialog.css
+++ b/src/Components/Popup/EditMediaDialog.css
@@ -31,6 +31,7 @@
     border-bottom-style: solid;
     border-color: var(--border);
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     cursor: default;
 }
@@ -42,6 +43,7 @@
     min-height: 24px;
     overflow-x: hidden;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     padding: 12px 24px 12px 24px;
     white-space: pre-wrap;

--- a/src/Components/Popup/ForwardDialog.css
+++ b/src/Components/Popup/ForwardDialog.css
@@ -16,6 +16,7 @@
     flex: 1 1 auto;
     padding: 12px 24px;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
 }
 
 .forward-dialog-search-list {
@@ -33,6 +34,7 @@
     align-content: start;
     padding: 12px 24px;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
 }
 
@@ -46,6 +48,7 @@
     border-bottom-style: solid;
     border-color: var(--border);
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
 }
 
@@ -61,6 +64,7 @@
     min-height: 24px;
     overflow-x: hidden;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     padding: 12px 24px 12px 24px;
     white-space: pre-wrap;

--- a/src/Components/Viewer/MediaCaption.css
+++ b/src/Components/Viewer/MediaCaption.css
@@ -20,6 +20,7 @@
 .media-caption-wrapper {
     max-height: 140px;
     overflow-y: auto;
+    scrollbar-width: thin; /* this property right here is specific to firefox and works with firefox only. It ensures to have a thinner scrollabr like on webkit and chrome */
     -webkit-overflow-scrolling: touch;
     overflow-x: hidden;
 }

--- a/src/TelegramApp.css
+++ b/src/TelegramApp.css
@@ -27,7 +27,6 @@ body {
     color: var(--text-primary);
 
     scrollbar-color: rgba(0, 0, 0, 0.25) transparent;
-    scrollbar-width: thin;
 }
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
Css rule scrollbar-width: thin; Must be added whenever overscroll is present to apply firefox thin rule