### PR TITLE
Fix excess api request for getMessageLinkInfo

### DIFF
--- a/src/Components/ColumnLeft/Search/Search.js
+++ b/src/Components/ColumnLeft/Search/Search.js
@@ -23,6 +23,7 @@ import { getCyrillicInput, getLatinInput } from '../../../Utils/Language';
 import { orderCompare } from '../../../Utils/Common';
 import { getChatOrder } from '../../../Utils/Chat';
 import { modalManager } from '../../../Utils/Modal';
+import { isTelegramLink } from '../../../Utils/Url';
 import { SCROLL_PRECISION, SEARCH_GLOBAL_TEXT_MIN, USERNAME_LENGTH_MIN } from '../../../Constants';
 import ChatStore from '../../../Stores/ChatStore';
 import FileStore from '../../../Stores/FileStore';
@@ -257,7 +258,7 @@ class Search extends React.Component {
         MessageStore.setItems(messages.messages);
 
         let linkMessage = null;
-        if (!chatId) {
+        if (!chatId && isTelegramLink(text)) {
             try {
                 const messageLinkInfo = await TdLibController.send({
                     '@type': 'getMessageLinkInfo',


### PR DESCRIPTION
**Problem:**
On every search type app does an excess request to API `getMessageLinkInfo` and receives the error:
```
{
  @client_id: 1,   
  @extra: { query_id: 1111 },   
  @type: "error”,   
  code: 400,   
  message: "Invalid message link URL"
}
```

**Solution:**
Check that text is a telegram link.

**Details:**
We also could check that link is a message link (a subset of telegram link) which looks like `https://t.me/<channel>/<message_id>`, but I can't find any documentation for all available patterns, so didn't implement it to avoid a false negative.